### PR TITLE
Print status example

### DIFF
--- a/bambulabs_api/client.py
+++ b/bambulabs_api/client.py
@@ -71,6 +71,17 @@ class Printer:
         """
         return self.mqtt_client.current_layer_num()
 
+    def total_layer_num(self):
+        """
+        Get total layer number
+
+        Returns
+        -------
+        int
+            Total layer number
+        """
+        return self.mqtt_client.total_layer_num()
+
     def camera_start(self):
         """
         Start the camera

--- a/bambulabs_api/client.py
+++ b/bambulabs_api/client.py
@@ -60,6 +60,17 @@ class Printer:
         """
         return self.mqtt_client.is_connected()
 
+    def current_layer_num(self):
+        """
+        Get current layer number
+
+        Returns
+        -------
+        int
+            Current layer number
+        """
+        return self.mqtt_client.current_layer_num()
+
     def camera_start(self):
         """
         Start the camera

--- a/examples/Basic/basic_subscription.py
+++ b/examples/Basic/basic_subscription.py
@@ -34,8 +34,13 @@ if __name__ == '__main__':
             bed_temperature = printer.get_bed_temperature()
             nozzle_temperature = printer.get_nozzle_temperature()
             remaining_time = printer.get_time()
-            finish_time = datetime.datetime.now() + datetime.timedelta(minutes=int(remaining_time))
-            finish_time_format = finish_time.strftime("%Y-%m-%d %H:%M:%S")
+            if remaining_time is not None:
+                finish_time = datetime.datetime.now() + datetime.timedelta(
+                    minutes=int(remaining_time))
+                finish_time_format = finish_time.strftime("%Y-%m-%d %H:%M:%S")
+            else:
+                finish_time_format = "NA"
+
             print(
                 f'''Printer status: {status}
                 Layers: {layer_num}/{total_layer_num}
@@ -45,13 +50,17 @@ if __name__ == '__main__':
                 Remaining time: {remaining_time}m
                 Finish time: {finish_time_format}
                 '''
-                )
+            )
 
             if debug:
                 import json
                 print("=" * 100)
                 print("Printer MQTT Dump")
-                print(json.dumps(printer.mqtt_dump(), sort_keys=True, indent=2))
+                print(json.dumps(
+                    printer.mqtt_dump(),
+                    sort_keys=True,
+                    indent=2
+                ))
                 print("=" * 100)
     finally:
         # Disconnect from the Bambulabs 3D printer

--- a/examples/Basic/basic_subscription.py
+++ b/examples/Basic/basic_subscription.py
@@ -7,7 +7,7 @@ IP = '192.168.1.200'
 SERIAL = 'AC12309BH109'
 ACCESS_CODE = '12347890'
 
-env = os.getenv("env", "debug")
+debug = os.getenv("debug", False)
 
 if __name__ == '__main__':
     print('Starting bambulabs_api example')
@@ -47,10 +47,11 @@ if __name__ == '__main__':
                 '''
                 )
 
-            if env == "debug":
+            if debug:
+                import json
                 print("=" * 100)
                 print("Printer MQTT Dump")
-                print(printer.mqtt_dump())
+                print(json.dumps(printer.mqtt_dump(), sort_keys=True, indent=2))
                 print("=" * 100)
     finally:
         # Disconnect from the Bambulabs 3D printer

--- a/examples/Basic/basic_subscription.py
+++ b/examples/Basic/basic_subscription.py
@@ -1,6 +1,7 @@
 import time
 import bambulabs_api as bl
 import os
+import datetime
 
 IP = '192.168.1.200'
 SERIAL = 'AC12309BH109'
@@ -27,11 +28,24 @@ if __name__ == '__main__':
 
             # Get the printer status
             status = printer.get_state()
+            percentage = printer.get_percentage()
+            layer_num = printer.current_layer_num()
+            total_layer_num = printer.total_layer_num()
             bed_temperature = printer.get_bed_temperature()
             nozzle_temperature = printer.get_nozzle_temperature()
+            remaining_time = printer.get_time()
+            finish_time = datetime.datetime.now() + datetime.timedelta(minutes=int(remaining_time))
+            finish_time_format = finish_time.strftime("%Y-%m-%d %H:%M:%S")
             print(
-                f'Printer status: {status}, Bed temp: {bed_temperature}, '
-                f'Nozzle temp: {nozzle_temperature}')
+                f'''Printer status: {status}
+                Layers: {layer_num}/{total_layer_num}
+                percentage: {percentage}%
+                Bed temp: {bed_temperature} ºC
+                Nozzle temp: {nozzle_temperature} ºC
+                Remaining time: {remaining_time}m
+                Finish time: {finish_time_format}
+                '''
+                )
 
             if env == "debug":
                 print("=" * 100)


### PR DESCRIPTION
Just putting together basic print status example to allow users to get started quickly

- Adding layer info to client fomr mqtt
- Adding an example for print status

Example result (during a print):

```
Starting bambulabs_api example
Connecting to BambuLab 3D printer
IP: 192.168.1.140
Serial: ************
Access Code: *******
Starting camera thread.

Printer status: RUNNING
Percentage: 53%
Layers: 17/72
Nozzle temp: 220.0625
Bed temp: 64.625
Remaining time: 21m
Finish time: 2025-02-25 18:52:55
```

Let me know if this has some interest and if any change on code, example or docs is needed