### PR TITLE
Make `PrinterCamera` client reconnectable.

### DIFF
--- a/bambulabs_api/camera_client.py
+++ b/bambulabs_api/camera_client.py
@@ -26,9 +26,7 @@ class PrinterCamera:
         self.__hostname = str(hostname)
         self.__port = port
 
-        self.__thread = Thread(target=self.retriever)
-        self.__thread.daemon = True
-
+        self.__thread = None
         self.last_frame = None
         self.alive = False
 
@@ -44,6 +42,8 @@ class PrinterCamera:
         """
         if not self.alive:
             self.alive = True
+            self.__thread = Thread(target=self.retriever)
+            self.__thread.daemon = True
             self.__thread.start()
             return True
         else:
@@ -54,7 +54,9 @@ class PrinterCamera:
         Stop the camera client
         """
         self.alive = False
-        self.__thread.join()
+        if self.__thread is not None:
+            self.__thread.join()
+            self.__thread = None
 
     def get_frame(self):
         if self.last_frame is None:

--- a/tests/test_camera_client.py
+++ b/tests/test_camera_client.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from bambulabs_api.camera_client import PrinterCamera
+
+
+def test_camera_is_reusable():
+    camera = PrinterCamera('1.2.3.4', 'fake_code')
+
+    # Mock the retriever method so it doesn't do any network I/O.
+    with patch.object(camera, 'retriever', return_value=None):
+        # First cycle
+        camera.start()
+        camera.stop()
+
+        # Second cycle
+        camera.start()  # This was failing before.
+        camera.stop()


### PR DESCRIPTION
# Description

Before this fix calling `PrinterCamera.connect()` after a `.disconnect()` would raise a `RuntimeError: threads can only be started once`, as `PrinterCamera.__thread` was created only once in `PrinterCamera.__init__`, and it looks like the `Thread` objects can not be reused.

## Printer

All of them.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)